### PR TITLE
Fix dpi in Win7 and Win 10

### DIFF
--- a/GGMSaveManager/App.config
+++ b/GGMSaveManager/App.config
@@ -1,9 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <appSettings>
-        <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
+        <add key="EnableWindowsFormsHighDpiAutoResizing" value="true"/>
     </appSettings>
+    <System.Windows.Forms.ApplicationConfigurationSection>
+        <add key="DpiAwareness" value="PerMonitorV2"/>
+    </System.Windows.Forms.ApplicationConfigurationSection>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/GGMSaveManager/App.config
+++ b/GGMSaveManager/App.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <appSettings>
+        <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
+    </appSettings>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>

--- a/GGMSaveManager/DPI.cs
+++ b/GGMSaveManager/DPI.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+namespace GGMSaveManager
+{
+    class DPI
+    {
+        // from https://stackoverflow.com/questions/5977445/how-to-get-windows-display-settings/5978597#5978597
+
+        [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
+        public static extern int GetDeviceCaps(IntPtr hDC, int nIndex);
+
+        public enum DeviceCap
+        {
+            VERTRES = 10,
+            DESKTOPVERTRES = 117
+        }
+
+        private static double GetWindowsScreenScalingFactor(bool percentage = true)
+        {
+            //Create Graphics object from the current windows handle
+            Graphics GraphicsObject = Graphics.FromHwnd(IntPtr.Zero);
+            //Get Handle to the device context associated with this Graphics object
+            IntPtr DeviceContextHandle = GraphicsObject.GetHdc();
+            //Call GetDeviceCaps with the Handle to retrieve the Screen Height
+            int LogicalScreenHeight = GetDeviceCaps(DeviceContextHandle, (int)DeviceCap.VERTRES);
+            int PhysicalScreenHeight = GetDeviceCaps(DeviceContextHandle, (int)DeviceCap.DESKTOPVERTRES);
+            //DisplayInformation ed111 = Windows.Graphics.Display.DisplayInformation;
+            //float ed = GraphicsObject.DpiY;
+            //Divide the Screen Heights to get the scaling factor and round it to two decimals
+            double ScreenScalingFactor = Math.Round((double)PhysicalScreenHeight / (double)LogicalScreenHeight, 2);
+            //If requested as percentage - convert it
+            if (percentage)
+            {
+                ScreenScalingFactor *= 100.0;
+            }
+            //Release the Handle and Dispose of the GraphicsObject object
+            GraphicsObject.ReleaseHdc(DeviceContextHandle);
+            GraphicsObject.Dispose();
+            //Return the Scaling Factor
+            return ScreenScalingFactor;
+        }
+
+        /// <summary>
+        /// Mulitiplies width and height by the "DPI" scaling value - i.e. if Windows is set to 125% scaling, this will return 1.25 * input.
+        /// </summary>
+        public static int MultiplyByDPIRatio(int input)
+        {
+            int newInt = 0; // (int)(input * DPI.GetWindowsScreenScalingFactor(false));
+            double scalingFactor = DPI.GetWindowsScreenScalingFactor(false);
+            newInt = (int)(input * scalingFactor);
+
+            return newInt;
+        }
+    }
+}

--- a/GGMSaveManager/DPI.cs
+++ b/GGMSaveManager/DPI.cs
@@ -29,8 +29,6 @@ namespace GGMSaveManager
             //Call GetDeviceCaps with the Handle to retrieve the Screen Height
             int LogicalScreenHeight = GetDeviceCaps(DeviceContextHandle, (int)DeviceCap.VERTRES);
             int PhysicalScreenHeight = GetDeviceCaps(DeviceContextHandle, (int)DeviceCap.DESKTOPVERTRES);
-            //DisplayInformation ed111 = Windows.Graphics.Display.DisplayInformation;
-            //float ed = GraphicsObject.DpiY;
             //Divide the Screen Heights to get the scaling factor and round it to two decimals
             double ScreenScalingFactor = Math.Round((double)PhysicalScreenHeight / (double)LogicalScreenHeight, 2);
             //If requested as percentage - convert it
@@ -50,10 +48,10 @@ namespace GGMSaveManager
         /// </summary>
         public static int MultiplyByDPIRatio(int input)
         {
-            int newInt = 0; // (int)(input * DPI.GetWindowsScreenScalingFactor(false));
+            int newInt = 0;
             double scalingFactor = DPI.GetWindowsScreenScalingFactor(false);
             newInt = (int)(input * scalingFactor);
-
+            //This will return 1 for Windows 7, but the input value should already be "scaled" from 100%
             return newInt;
         }
     }

--- a/GGMSaveManager/FormOperations.cs
+++ b/GGMSaveManager/FormOperations.cs
@@ -53,7 +53,7 @@ namespace GGMSaveManager
         /// </summary>
         public static Size ScaleSize(Size size, float width, float height)
         {
-            return new Size(size.Width * (int)width, size.Height * (int)height);
+            return new Size((int)(DPI.MultiplyByDPIRatio(size.Width) * width), (int)(DPI.MultiplyByDPIRatio(size.Height) * height));
         }
 
         /// <summary>
@@ -100,8 +100,7 @@ namespace GGMSaveManager
 
 
             int buttonTop = MulDiv(41, dialogUnits.Height, 8);
-            //Command buttons should be 50x14 dlus
-            Size buttonSize = ScaleSize(new Size(72, 27), dialogUnits.Width / 4, dialogUnits.Height / 8);
+            Size buttonSize = ScaleSize(new Size(72, 27), dialogUnits.Width / 7, dialogUnits.Height / 15);
 
             System.Windows.Forms.Button bbOk = new System.Windows.Forms.Button();
             bbOk.Parent = form;

--- a/GGMSaveManager/GGMSaveManager.csproj
+++ b/GGMSaveManager/GGMSaveManager.csproj
@@ -55,6 +55,9 @@
   <PropertyGroup>
     <ApplicationIcon>GGMSaveManager.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -102,6 +105,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <None Include="app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/GGMSaveManager/GGMSaveManager.csproj
+++ b/GGMSaveManager/GGMSaveManager.csproj
@@ -27,6 +27,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -72,6 +73,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DPI.cs" />
     <Compile Include="FileData.cs" />
     <Compile Include="FileOperations.cs" />
     <Compile Include="frmMain.cs">
@@ -105,7 +107,9 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
-    <None Include="app.manifest" />
+    <None Include="app.manifest">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -117,7 +121,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.6.1">

--- a/GGMSaveManager/app.manifest
+++ b/GGMSaveManager/app.manifest
@@ -31,7 +31,7 @@
       <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
 
       <!-- Windows 7 -->
-      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
 
       <!-- Windows 8 -->
       <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
@@ -40,7 +40,7 @@
       <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
 
       <!-- Windows 10 -->
-      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
 
     </application>
   </compatibility>

--- a/GGMSaveManager/app.manifest
+++ b/GGMSaveManager/app.manifest
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+
+
+</assembly>

--- a/GGMSaveManager/frmMain.Designer.cs
+++ b/GGMSaveManager/frmMain.Designer.cs
@@ -177,13 +177,14 @@
             // 
             // listBoxFile1
             // 
-            this.listBoxFile1.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.listBoxFile1.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawVariable;
             this.listBoxFile1.FormattingEnabled = true;
             this.listBoxFile1.Location = new System.Drawing.Point(12, 148);
             this.listBoxFile1.Name = "listBoxFile1";
             this.listBoxFile1.Size = new System.Drawing.Size(376, 290);
             this.listBoxFile1.TabIndex = 10;
             this.listBoxFile1.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.listBoxFile1_DrawItem);
+            this.listBoxFile1.MeasureItem += new System.Windows.Forms.MeasureItemEventHandler(this.listBox_MeasureItem);
             this.listBoxFile1.SelectedIndexChanged += new System.EventHandler(this.listBoxFile1_SelectedIndexChanged);
             // 
             // openFileDialog3
@@ -339,13 +340,14 @@
             // 
             // listBoxFile2
             // 
-            this.listBoxFile2.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.listBoxFile2.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawVariable;
             this.listBoxFile2.FormattingEnabled = true;
             this.listBoxFile2.Location = new System.Drawing.Point(412, 148);
             this.listBoxFile2.Name = "listBoxFile2";
             this.listBoxFile2.Size = new System.Drawing.Size(376, 290);
             this.listBoxFile2.TabIndex = 26;
             this.listBoxFile2.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.listBoxFile2_DrawItem);
+            this.listBoxFile2.MeasureItem += new System.Windows.Forms.MeasureItemEventHandler(this.listBox_MeasureItem);
             this.listBoxFile2.SelectedIndexChanged += new System.EventHandler(this.listBoxFile2_SelectedIndexChanged);
             // 
             // txtFile2

--- a/GGMSaveManager/frmMain.cs
+++ b/GGMSaveManager/frmMain.cs
@@ -51,6 +51,12 @@ namespace GGMSaveManager
             FormOperations.DrawSlotsListBox(sender, e, formData.fileData[1].saveBin);
         }
 
+        private void listBox_MeasureItem(object sender, MeasureItemEventArgs e)
+        {
+            // Handle the MeasureItem event for an owner-drawn ListBox, adjust item height to match font size (for DPI).
+            e.ItemHeight = DPI.MultiplyByDPIRatio(((ListBox)sender).Font.Height);
+        }
+
         private void listBoxFile1_SelectedIndexChanged(object sender, EventArgs e)
         {
             FormOperations.CheckFileSlotUI(formData.fileData[0]);


### PR DESCRIPTION
All control elements should now display correctly with higher DPI scaling - Windows 7 and Windows 10 tested.